### PR TITLE
Allow setting of base URL

### DIFF
--- a/src/lib/Plunk.ts
+++ b/src/lib/Plunk.ts
@@ -5,6 +5,7 @@ import { TokenError } from "../errors/TokenError";
 
 export class Plunk {
   private readonly key: string;
+  private readonly baseUrl?: string = "https://api.useplunk.com/v1/";
 
   private async fetch<T>({
     json,
@@ -16,7 +17,7 @@ export class Plunk {
     headers?: Record<string, string>;
   }) {
     const res = await fetch(
-      new URL(url, "https://api.useplunk.com/v1/").toString(),
+      new URL(url, this.baseUrl).toString(),
       {
         ...options,
         headers: {
@@ -46,8 +47,9 @@ export class Plunk {
     return data as T;
   }
 
-  constructor(key: string) {
+  constructor(key: string, baseUrl?:string) {
     this.key = key;
+    this.baseUrl = baseUrl;
   }
 
   /**


### PR DESCRIPTION
I'm self hosting Plunk and wanted to use this package, but found out there wasn't a way to set the URL to my deployment instead. I've not tested if this works, but I've patched the package and changed the URL to mine (e.g.`plunk.example.com/api/v1`) and that worked, so I think this should too :) 